### PR TITLE
Sets `client_certificate_config` so Terraform stops recreating the clusters

### DIFF
--- a/terraform/components/in-scope/cluster.tf
+++ b/terraform/components/in-scope/cluster.tf
@@ -64,6 +64,10 @@ resource "google_container_cluster" "primary" {
   master_auth {
     username = ""
     password = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
   }
 
   ip_allocation_policy {

--- a/terraform/components/out-of-scope/cluster.tf
+++ b/terraform/components/out-of-scope/cluster.tf
@@ -64,6 +64,10 @@ resource "google_container_cluster" "primary" {
   master_auth {
     username = ""
     password = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
   }
 
   ip_allocation_policy {


### PR DESCRIPTION
I'm encountering an issue where each Terraform run for the GKE components will re-create the cluster because it thinks that `client_certificate_config` is configured differently than the state file's version.

This change fixes it but I'm not super confident in adding this to `master` unless you're seeing the issue and agree with my fix here...